### PR TITLE
fix: parse the PROJECTCOMPATVERSION from the VBA project if it exists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calamine"
-version = "0.19.1"
+version = "0.19.2"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"
@@ -16,7 +16,7 @@ edition = "2018"
 byteorder = "1.3.4"
 codepage = "0.1.1"
 encoding_rs = "0.8.24"
-log = "0.4.11"
+tracing = "0.1"
 once_cell = { version = "1.15", optional = true }
 serde = "1.0.116"
 quick-xml = { version = "0.25", features = ["encoding"] }

--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -5,7 +5,7 @@ use std::cmp::min;
 use std::convert::TryInto;
 use std::io::Read;
 
-use log::debug;
+use tracing::debug;
 
 use encoding_rs::{Encoding, UTF_16LE, UTF_8};
 

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -6,7 +6,7 @@ use std::fmt::Write;
 use std::io::{Read, Seek, SeekFrom};
 use std::marker::PhantomData;
 
-use log::debug;
+use tracing::debug;
 
 use crate::cfb::{Cfb, XlsEncoding};
 use crate::utils::{push_column, read_f64, read_i32, read_u16, read_u32};

--- a/src/xlsb.rs
+++ b/src/xlsb.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::io::{BufReader, Read, Seek};
 use std::string::String;
 
-use log::debug;
+use tracing::debug;
 
 use encoding_rs::UTF_16LE;
 use quick_xml::events::attributes::Attribute;

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -4,11 +4,11 @@ use std::io::BufReader;
 use std::io::{Read, Seek};
 use std::str::FromStr;
 
-use tracing::warn;
 use quick_xml::events::attributes::{Attribute, Attributes};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::name::QName;
 use quick_xml::Reader as XmlReader;
+use tracing::warn;
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
 

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -4,7 +4,7 @@ use std::io::BufReader;
 use std::io::{Read, Seek};
 use std::str::FromStr;
 
-use log::warn;
+use tracing::warn;
 use quick_xml::events::attributes::{Attribute, Attributes};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::name::QName;


### PR DESCRIPTION
## Description

Fixes an issue parsing files that contain a `PROJECTCOMPATVERSION` section in the XLS file's VBA project.

---

An XLS document use a compound file binary ([CFB](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-xls/2e6147d9-e8ad-48b0-9ff7-bbfc51ca950d?source=recommendations)) file format to describe their contents. The CFB may contain a directory named '_VBA_PROJECT_CUR' described by the [OVBA file format structure](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-ovba/575462ba-bf67-4190-9fac-c275523c75fc). The CFB's [PROJECTINFORMATION record](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-ovba/5abef063-3661-46dd-ba80-8cb507afdb1d) contains an optional [PROJECTCOMPATVERSION](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-ovba/ed5d7ede-5d7d-4645-bba3-ddfd9bdc76ed) 10 byte record. The possible existence of this record wasn't properly being account for, preventing some XLS files from being parsed. 

## Changes
- use tracing instead of log
- advance the stream 10 bytes if the file contains a `PROJECTCOMPATVERSION`