### PR TITLE
fix: track the row and cell count as a fallback if cell is missing r attr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ encoding_rs = "0.8.24"
 tracing = "0.1"
 once_cell = { version = "1.15", optional = true }
 serde = "1.0.116"
-quick-xml = { version = "0.25", features = ["encoding"] }
+quick-xml = { version = "0.27", features = ["encoding"] }
 zip = { version = "0.6.2", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4.22", features = ["serde"], optional = true, default-features = false }
 

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -879,13 +879,26 @@ where
 {
     let mut buf = Vec::new();
     let mut cell_buf = Vec::new();
+    let mut rows = 0;
+    let mut cols = 0;
     loop {
         buf.clear();
         match xml.read_event_into(&mut buf) {
+            Ok(Event::Start(r_element)) if r_element.local_name().as_ref() == b"row" => {
+                cols = 0;
+            }
+            Ok(Event::End(r_element)) if r_element.local_name().as_ref() == b"row" => {
+                rows += 1;
+            }
+            Ok(Event::End(c_element)) if c_element.local_name().as_ref() == b"c" => {
+                cols += 1;
+            }
             Ok(Event::Start(ref c_element)) if c_element.local_name().as_ref() == b"c" => {
-                let pos = get_attribute(c_element.attributes(), QName(b"r"))
-                    .and_then(|o| o.ok_or(XlsxError::CellRAttribute))
-                    .and_then(get_row_column)?;
+                let pos = match get_attribute(c_element.attributes(), QName(b"r")) {
+                    Ok(Some(r_val)) => get_row_column(r_val),
+                    Ok(None) => Ok((rows, cols)),
+                    Err(err) => Err(err),
+                }?;
                 loop {
                     cell_buf.clear();
                     match xml.read_event_into(&mut cell_buf) {


### PR DESCRIPTION
# Description

Calamine expects the file's XML cells to have a "r" value (cell ref), but it's not required per the spec. This results in a parser error while the xlsx file may actually be valid.

# Changes

When parsing the worksheet, track the row and cell count as a fallback for cell's missing the "r" attr.