### PR TITLE
fix: trim string before converting to usize

### DIFF
--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -980,7 +980,7 @@ fn read_sheet_data(
         {
             Some(b"s") => {
                 // shared string
-                let idx: usize = v.parse()?;
+                let idx: usize = v.trim().parse()?;
                 Ok(DataType::String(strings[idx].clone()))
             }
             Some(b"b") => {


### PR DESCRIPTION
Background:
XLSX interns some shared strings and then looks them up by their index/position in the shared string array. 

Problem:
If the software that created the file included leading or trailing whitespace in the stringified index, Calamine can't convert it to a usize. (ParseInt error)

Fix:
Before trying to parse the string to a usize, trim it.