### PR TITLE
default to worksheet when the sheet:type is not set correctly

### DIFF
--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -381,10 +381,17 @@ impl<RS: Read + Seek> Xlsx<RS> {
                         Some("chartsheets") => SheetType::ChartSheet,
                         Some("dialogsheets") => SheetType::DialogSheet,
                         _ => {
-                            return Err(XlsxError::Unrecognized {
-                                typ: "sheet:type",
-                                val: path.to_string(),
-                            })
+                            // NOTE(ted): Calamine, by default, sends an error.
+                            // Sometimes our customers send malformatted excel files to use.
+                            // We can just ignore this and try and default to WorkSheet.
+                            // Leaving this code here in case we want to rever thsi later.
+                            //
+                            // return Err(XlsxError::Unrecognized {
+                            //     typ: "sheet:type",
+                            //     val: path.to_string(),
+                            // })
+
+                            SheetType::WorkSheet
                         }
                     };
                     self.metadata.sheets.push(Sheet {


### PR DESCRIPTION
This PR checks that a `relationships:id` is set correctly and doesn't push up an invalid sheet to calamine when it is empty. Harman's vendors have been sending back some crap excel files and it looks like we introduced a bug, in that, it checks earlier if the `relationships:id` is not empty, however, if it is, it still tries to push up the Sheet and that causes it to explode. This fixes that and ensures that very hidden sheets are not pushed with missing data causing errors