### PR TITLE
OSM-9171

### DIFF
--- a/src/xlsx/cells_reader.rs
+++ b/src/xlsx/cells_reader.rs
@@ -243,7 +243,7 @@ fn read_v<'s>(
     match get_attribute(c_element.attributes(), QName(b"t"))? {
         Some(b"s") => {
             // shared string
-            let idx: usize = v.parse()?;
+            let idx: usize = v.trim().parse()?;
             Ok(DataRef::SharedString(&strings[idx]))
         }
         Some(b"b") => {


### PR DESCRIPTION
trim indexes to ensure calamine can parse them in malformatted excel files